### PR TITLE
fix: Compile error for clang 12

### DIFF
--- a/zlib/gzguts.h
+++ b/zlib/gzguts.h
@@ -29,6 +29,8 @@
 
 #ifdef _WIN32
 #  include <stddef.h>
+#else
+#  include <unistd.h>
 #endif
 
 #if defined(__TURBOC__) || defined(_MSC_VER) || defined(_WIN32)


### PR DESCRIPTION
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: arm64-apple-darwin20.2.0
Thread model: posix